### PR TITLE
16 byte aligned struct allocation

### DIFF
--- a/Source/V8/Private/StructMemoryInstance.h
+++ b/Source/V8/Private/StructMemoryInstance.h
@@ -88,7 +88,7 @@ struct FStructMemoryInstance
 	TSharedPtr<FStructMemoryInstance> Parent;
 
 	// Independent memory buffer
-	TArray<uint8> Buffer;
+	TArray<uint8, TAlignedHeapAllocator<16>> Buffer;
 
 	uint8* GetMemory()
 	{


### PR DESCRIPTION
Adding byte alignment to ensure that FQuat and FTransform structs are
always aligned. Resolves an occasional crash from `new FQuat()` in
script.