### PR TITLE
Add Node compatibility sufficient to support source-map-support

### DIFF
--- a/Content/Scripts/fs.js
+++ b/Content/Scripts/fs.js
@@ -1,5 +1,13 @@
+var filePrefix = "file://"
+function prefixTrim(path) {
+    if (path.startsWith(filePrefix))
+        return decodeURI(path.substr(filePrefix.length))
+    return path
+}
+
 module.exports = {
     readFileSync : function (path,encoding) {
+        path = prefixTrim(path)
         var text = Context.ReadScriptFile(path);
         if (encoding == 'utf8') return text;
         return {
@@ -7,5 +15,10 @@ module.exports = {
                 return text;
             }
         }
+    },
+
+    existsSync : function (path) {
+        path = prefixTrim(path)
+        return JavascriptLibrary.FileExists(path)
     }
 };

--- a/Content/Scripts/internal/errors.js
+++ b/Content/Scripts/internal/errors.js
@@ -1,0 +1,485 @@
+// Copied from NodeJS v9.2.0, lib/internal/errors.js
+// Changes: Replaced process.binding call with string "[Unknown]"
+
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/* eslint documented-errors: "error" */
+/* eslint alphabetize-errors: "error" */
+
+'use strict';
+
+// The whole point behind this internal module is to allow Node.js to no
+// longer be forced to treat every error message change as a semver-major
+// change. The NodeError classes here all expose a `code` property whose
+// value statically and permanently identifies the error. While the error
+// message may change, the code should not.
+
+const kCode = Symbol('code');
+const messages = new Map();
+
+const kMaxLength = "[Unknown]";
+const { defineProperty } = Object;
+
+// Lazily loaded
+var util = null;
+
+function makeNodeError(Base) {
+  return class NodeError extends Base {
+    constructor(key, ...args) {
+      super(message(key, args));
+      defineProperty(this, kCode, {
+        configurable: true,
+        enumerable: false,
+        value: key,
+        writable: true
+      });
+    }
+
+    get name() {
+      return `${super.name} [${this[kCode]}]`;
+    }
+
+    set name(value) {
+      defineProperty(this, 'name', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+
+    get code() {
+      return this[kCode];
+    }
+
+    set code(value) {
+      defineProperty(this, 'code', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+  };
+}
+
+class AssertionError extends Error {
+  constructor(options) {
+    if (typeof options !== 'object' || options === null) {
+      throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
+    }
+    var { actual, expected, message, operator, stackStartFunction } = options;
+    if (message) {
+      super(message);
+    } else {
+      if (actual && actual.stack && actual instanceof Error)
+        actual = `${actual.name}: ${actual.message}`;
+      if (expected && expected.stack && expected instanceof Error)
+        expected = `${expected.name}: ${expected.message}`;
+      if (util === null) util = require('util');
+      super(`${util.inspect(actual).slice(0, 128)} ` +
+        `${operator} ${util.inspect(expected).slice(0, 128)}`);
+    }
+
+    this.generatedMessage = !message;
+    this.name = 'AssertionError [ERR_ASSERTION]';
+    this.code = 'ERR_ASSERTION';
+    this.actual = actual;
+    this.expected = expected;
+    this.operator = operator;
+    Error.captureStackTrace(this, stackStartFunction);
+  }
+}
+
+// This is defined here instead of using the assert module to avoid a
+// circular dependency. The effect is largely the same.
+function internalAssert(condition, message) {
+  if (!condition) {
+    throw new AssertionError({
+      message,
+      actual: false,
+      expected: true,
+      operator: '=='
+    });
+  }
+}
+
+function message(key, args) {
+  const msg = messages.get(key);
+  internalAssert(msg, `An invalid error message key was used: ${key}.`);
+  let fmt;
+  if (typeof msg === 'function') {
+    fmt = msg;
+  } else {
+    if (util === null) util = require('util');
+    fmt = util.format;
+    if (args === undefined || args.length === 0)
+      return msg;
+    args.unshift(msg);
+  }
+  return String(fmt.apply(null, args));
+}
+
+// Utility function for registering the error codes. Only used here. Exported
+// *only* to allow for testing.
+function E(sym, val) {
+  messages.set(sym, typeof val === 'function' ? val : String(val));
+}
+
+module.exports = exports = {
+  message,
+  Error: makeNodeError(Error),
+  TypeError: makeNodeError(TypeError),
+  RangeError: makeNodeError(RangeError),
+  URIError: makeNodeError(URIError),
+  AssertionError,
+  E // This is exported only to facilitate testing.
+};
+
+// To declare an error message, use the E(sym, val) function above. The sym
+// must be an upper case string. The val can be either a function or a string.
+// The return value of the function must be a string.
+// Examples:
+// E('EXAMPLE_KEY1', 'This is the error value');
+// E('EXAMPLE_KEY2', (a, b) => return `${a} ${b}`);
+//
+// Once an error code has been assigned, the code itself MUST NOT change and
+// any given error code must never be reused to identify a different error.
+//
+// Any error code added here should also be added to the documentation
+//
+// Note: Please try to keep these in alphabetical order
+E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
+E('ERR_ASSERTION', '%s');
+E('ERR_ASYNC_CALLBACK', (name) => `${name} must be a function`);
+E('ERR_ASYNC_TYPE', (s) => `Invalid name for async "type": ${s}`);
+E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
+E('ERR_BUFFER_TOO_LARGE',
+  `Cannot create a Buffer larger than 0x${kMaxLength.toString(16)} bytes`);
+E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
+E('ERR_CONSOLE_WRITABLE_STREAM',
+  'Console expects a writable stream instance for %s');
+E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s');
+E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found');
+E('ERR_CRYPTO_FIPS_FORCED',
+  'Cannot set FIPS mode, it was forced with --force-fips at startup.');
+E('ERR_CRYPTO_FIPS_UNAVAILABLE', 'Cannot set FIPS mode in a non-FIPS build.');
+E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16');
+E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called');
+E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed');
+E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s');
+E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign');
+E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
+  'Input buffers must have the same length');
+E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
+  `c-ares failed to set servers: "${err}" [${servers}]`);
+E('ERR_ENCODING_INVALID_ENCODED_DATA',
+  (enc) => `The encoded data was not valid for encoding ${enc}`);
+E('ERR_ENCODING_NOT_SUPPORTED',
+  (enc) => `The "${enc}" encoding is not supported`);
+E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
+E('ERR_HTTP2_CONNECT_AUTHORITY',
+  ':authority header is required for CONNECT requests');
+E('ERR_HTTP2_CONNECT_PATH',
+  'The :path header is forbidden for CONNECT requests');
+E('ERR_HTTP2_CONNECT_SCHEME',
+  'The :scheme header is forbidden for CONNECT requests');
+E('ERR_HTTP2_FRAME_ERROR',
+  (type, code, id) => {
+    let msg = `Error sending frame type ${type}`;
+    if (id !== undefined)
+      msg += ` for stream ${id}`;
+    msg += ` with code ${code}`;
+    return msg;
+  });
+E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
+  'Cannot specify additional headers after response initiated');
+E('ERR_HTTP2_HEADERS_OBJECT', 'Headers must be an object');
+E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
+E('ERR_HTTP2_HEADER_REQUIRED',
+  (name) => `The ${name} header is required`);
+E('ERR_HTTP2_HEADER_SINGLE_VALUE',
+  (name) => `Header field "${name}" must have only a single value`);
+E('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND',
+  'Cannot send informational headers after the HTTP message has been sent');
+E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
+  'Informational status codes cannot be used');
+E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
+  'HTTP/1 Connection specific headers are forbidden: "%s"');
+E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Invalid value "%s" for header "%s"');
+E('ERR_HTTP2_INVALID_INFO_STATUS',
+  (code) => `Invalid informational status code: ${code}`);
+E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
+  'Packed settings length must be a multiple of six');
+E('ERR_HTTP2_INVALID_PSEUDOHEADER',
+  (name) => `"${name}" is an invalid pseudoheader or is used incorrectly`);
+E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed');
+E('ERR_HTTP2_INVALID_SETTING_VALUE',
+  (name, value) => `Invalid value for setting "${name}": ${value}`);
+E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed');
+E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
+  (max) => `Maximum number of pending settings acknowledgements (${max})`);
+E('ERR_HTTP2_NO_SOCKET_MANIPULATION',
+  'HTTP/2 sockets should not be directly manipulated (e.g. read and written)');
+E('ERR_HTTP2_OUT_OF_STREAMS',
+  'No stream ID is available because maximum stream ID has been reached');
+E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
+  (code) => `Responses with ${code} status must not have a payload`);
+E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
+E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
+E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');
+E('ERR_HTTP2_SOCKET_BOUND',
+  'The socket is already bound to an Http2Session');
+E('ERR_HTTP2_STATUS_101',
+  'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2');
+E('ERR_HTTP2_STATUS_INVALID',
+  (code) => `Invalid status code: ${code}`);
+E('ERR_HTTP2_STREAM_CLOSED', 'The stream is already closed');
+E('ERR_HTTP2_STREAM_ERROR',
+  (code) => `Stream closed with error code ${code}`);
+E('ERR_HTTP2_STREAM_SELF_DEPENDENCY', 'A stream cannot depend on itself');
+E('ERR_HTTP2_UNSUPPORTED_PROTOCOL',
+  (protocol) => `protocol "${protocol}" is unsupported.`);
+E('ERR_HTTP_HEADERS_SENT',
+  'Cannot %s headers after they are sent to the client');
+E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
+E('ERR_HTTP_INVALID_STATUS_CODE',
+  (originalStatusCode) => `Invalid status code: ${originalStatusCode}`);
+E('ERR_HTTP_TRAILER_INVALID',
+  'Trailers are invalid with this transfer encoding');
+E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
+E('ERR_INSPECTOR_ALREADY_CONNECTED', 'The inspector is already connected');
+E('ERR_INSPECTOR_CLOSED', 'Session was closed');
+E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
+E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');
+E('ERR_INVALID_ARG_TYPE', invalidArgType);
+E('ERR_INVALID_ARG_VALUE',
+  (name, value) => {
+    return `The value "${String(value)}" is invalid for argument "${name}"`;
+  });
+E('ERR_INVALID_ARRAY_LENGTH',
+  (name, len, actual) => {
+    internalAssert(typeof actual === 'number', 'actual must be a number');
+    return `The array "${name}" (length ${actual}) must be of length ${len}.`;
+  });
+E('ERR_INVALID_ASYNC_ID', (type, id) => `Invalid ${type} value: ${id}`);
+E('ERR_INVALID_BUFFER_SIZE', 'Buffer size must be a multiple of %s');
+E('ERR_INVALID_CALLBACK', 'Callback must be a function');
+E('ERR_INVALID_CHAR', invalidChar);
+E('ERR_INVALID_CURSOR_POS',
+  'Cannot set cursor row without setting its column');
+E('ERR_INVALID_DOMAIN_NAME', 'Unable to determine the domain name');
+E('ERR_INVALID_FD', '"fd" must be a positive integer: %s');
+E('ERR_INVALID_FD_TYPE', 'Unsupported fd type: %s');
+E('ERR_INVALID_FILE_URL_HOST',
+  'File URL host must be "localhost" or empty on %s');
+E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
+E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
+E('ERR_INVALID_HTTP_TOKEN', '%s must be a valid HTTP token ["%s"]');
+E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s');
+E('ERR_INVALID_OPT_VALUE',
+  (name, value) => {
+    return `The value "${String(value)}" is invalid for option "${name}"`;
+  });
+E('ERR_INVALID_OPT_VALUE_ENCODING',
+  (value) => `The value "${String(value)}" is invalid for option "encoding"`);
+E('ERR_INVALID_PERFORMANCE_MARK', 'The "%s" performance mark has not been set');
+E('ERR_INVALID_PROTOCOL', (protocol, expectedProtocol) =>
+  `Protocol "${protocol}" not supported. Expected "${expectedProtocol}"`);
+E('ERR_INVALID_REPL_EVAL_CONFIG',
+  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
+E('ERR_INVALID_SYNC_FORK_INPUT',
+  'Asynchronous forks do not support Buffer, Uint8Array or string input: %s');
+E('ERR_INVALID_THIS', 'Value of "this" must be of type %s');
+E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple');
+E('ERR_INVALID_URI', 'URI malformed');
+E('ERR_INVALID_URL', 'Invalid URL: %s');
+E('ERR_INVALID_URL_SCHEME',
+  (expected) => `The URL must be ${oneOf(expected, 'scheme')}`);
+E('ERR_IPC_CHANNEL_CLOSED', 'Channel closed');
+E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected');
+E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe');
+E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
+E('ERR_METHOD_NOT_IMPLEMENTED', 'The %s method is not implemented');
+E('ERR_MISSING_ARGS', missingArgs);
+E('ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK',
+  'The ES Module loader may not return a format of \'dynamic\' when no ' +
+  'dynamicInstantiate function was provided');
+E('ERR_MISSING_MODULE', 'Cannot find module %s');
+E('ERR_MODULE_RESOLUTION_LEGACY', '%s not found by import in %s.' +
+  ' Legacy behavior in require() would have found it at %s');
+E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times');
+E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function');
+E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
+E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
+E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
+E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
+E('ERR_OUTOFMEMORY', 'Out of memory');
+E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
+E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
+E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
+E('ERR_SERVER_ALREADY_LISTEN',
+  'Listen method has been called more than once without closing.');
+E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
+E('ERR_SOCKET_BAD_BUFFER_SIZE', 'Buffer size must be a positive integer');
+E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536. Received %s.');
+E('ERR_SOCKET_BAD_TYPE',
+  'Bad socket type specified. Valid types are: udp4, udp6');
+E('ERR_SOCKET_BUFFER_SIZE',
+  (reason) => `Could not get or set buffer size: ${reason}`);
+E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
+E('ERR_SOCKET_CLOSED', 'Socket is closed');
+E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
+E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
+E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
+E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable');
+E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream');
+E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF');
+E('ERR_STREAM_READ_NOT_IMPLEMENTED', '_read() is not implemented');
+E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT', 'stream.unshift() after end event');
+E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');
+E('ERR_STREAM_WRITE_AFTER_END', 'write after end');
+E('ERR_TLS_CERT_ALTNAME_INVALID',
+  'Hostname/IP does not match certificate\'s altnames: %s');
+E('ERR_TLS_DH_PARAM_SIZE', (size) =>
+  `DH parameter size ${size} is less than 2048`);
+E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout');
+E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
+E('ERR_TLS_REQUIRED_SERVER_NAME',
+  '"servername" is required parameter for Server.addContext');
+E('ERR_TLS_SESSION_ATTACK', 'TSL session renegotiation attack detected');
+E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
+  'Calling transform done when still transforming');
+E('ERR_TRANSFORM_WITH_LENGTH_0',
+  'Calling transform done when writableState.length != 0');
+E('ERR_UNESCAPED_CHARACTERS',
+  (name) => `${name} contains unescaped characters`);
+E('ERR_UNHANDLED_ERROR',
+  (err) => {
+    const msg = 'Unhandled error.';
+    if (err === undefined) return msg;
+    return `${msg} (${err})`;
+  });
+E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s');
+E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s');
+E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s');
+E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s');
+E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
+E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
+E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
+  'See https://github.com/nodejs/node/wiki/Intl');
+E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
+  'At least one valid performance entry type is required');
+E('ERR_VALUE_OUT_OF_RANGE', (start, end, value) => {
+  return `The value of "${start}" must be ${end}. Received "${value}"`;
+});
+E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
+E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed');
+
+function invalidArgType(name, expected, actual) {
+  internalAssert(name, 'name is required');
+
+  // determiner: 'must be' or 'must not be'
+  let determiner;
+  if (typeof expected === 'string' && expected.startsWith('not ')) {
+    determiner = 'must not be';
+    expected = expected.replace(/^not /, '');
+  } else {
+    determiner = 'must be';
+  }
+
+  let msg;
+  if (Array.isArray(name)) {
+    var names = name.map((val) => `"${val}"`).join(', ');
+    msg = `The ${names} arguments ${determiner} ${oneOf(expected, 'type')}`;
+  } else if (name.endsWith(' argument')) {
+    // for the case like 'first argument'
+    msg = `The ${name} ${determiner} ${oneOf(expected, 'type')}`;
+  } else {
+    const type = name.includes('.') ? 'property' : 'argument';
+    msg = `The "${name}" ${type} ${determiner} ${oneOf(expected, 'type')}`;
+  }
+
+  // if actual value received, output it
+  if (arguments.length >= 3) {
+    msg += `. Received type ${actual !== null ? typeof actual : 'null'}`;
+  }
+  return msg;
+}
+
+function missingArgs(...args) {
+  internalAssert(args.length > 0, 'At least one arg needs to be specified');
+  let msg = 'The ';
+  const len = args.length;
+  args = args.map((a) => `"${a}"`);
+  switch (len) {
+    case 1:
+      msg += `${args[0]} argument`;
+      break;
+    case 2:
+      msg += `${args[0]} and ${args[1]} arguments`;
+      break;
+    default:
+      msg += args.slice(0, len - 1).join(', ');
+      msg += `, and ${args[len - 1]} arguments`;
+      break;
+  }
+  return `${msg} must be specified`;
+}
+
+function oneOf(expected, thing) {
+  internalAssert(expected, 'expected is required');
+  internalAssert(typeof thing === 'string', 'thing is required');
+  if (Array.isArray(expected)) {
+    const len = expected.length;
+    internalAssert(len > 0,
+                   'At least one expected value needs to be specified');
+    expected = expected.map((i) => String(i));
+    if (len > 2) {
+      return `one of ${thing} ${expected.slice(0, len - 1).join(', ')}, or ` +
+             expected[len - 1];
+    } else if (len === 2) {
+      return `one of ${thing} ${expected[0]} or ${expected[1]}`;
+    } else {
+      return `of ${thing} ${expected[0]}`;
+    }
+  } else {
+    return `of ${thing} ${String(expected)}`;
+  }
+}
+
+function bufferOutOfBounds(name, isWriting) {
+  if (isWriting) {
+    return 'Attempt to write outside buffer bounds';
+  } else {
+    return `"${name}" is outside of buffer bounds`;
+  }
+}
+
+function invalidChar(name, field) {
+  let msg = `Invalid character in ${name}`;
+  if (field) {
+    msg += ` ["${field}"]`;
+  }
+  return msg;
+}

--- a/Content/Scripts/path.js
+++ b/Content/Scripts/path.js
@@ -1,2 +1,1641 @@
-module.exports = {     
+// Copied from NodeJS v9.2.0, lib/path.js
+// Changes: Windows/Posix test at end has been replaced with UnrealJS equivalent
+
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const errors = require('internal/errors');
+
+function assertPath(path) {
+  if (typeof path !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
+  }
+}
+
+// Resolves . and .. elements in a path with directory names
+function normalizeStringWin32(path, allowAboveRoot) {
+  var res = '';
+  var lastSegmentLength = 0;
+  var lastSlash = -1;
+  var dots = 0;
+  var code;
+  for (var i = 0; i <= path.length; ++i) {
+    if (i < path.length)
+      code = path.charCodeAt(i);
+    else if (code === 47/*/*/ || code === 92/*\*/)
+      break;
+    else
+      code = 47/*/*/;
+    if (code === 47/*/*/ || code === 92/*\*/) {
+      if (lastSlash === i - 1 || dots === 1) {
+        // NOOP
+      } else if (lastSlash !== i - 1 && dots === 2) {
+        if (res.length < 2 || lastSegmentLength !== 2 ||
+            res.charCodeAt(res.length - 1) !== 46/*.*/ ||
+            res.charCodeAt(res.length - 2) !== 46/*.*/) {
+          if (res.length > 2) {
+            const start = res.length - 1;
+            var j = start;
+            for (; j >= 0; --j) {
+              if (res.charCodeAt(j) === 92/*\*/)
+                break;
+            }
+            if (j !== start) {
+              if (j === -1) {
+                res = '';
+                lastSegmentLength = 0;
+              } else {
+                res = res.slice(0, j);
+                lastSegmentLength = j;
+              }
+              lastSlash = i;
+              dots = 0;
+              continue;
+            }
+          } else if (res.length === 2 || res.length === 1) {
+            res = '';
+            lastSegmentLength = 0;
+            lastSlash = i;
+            dots = 0;
+            continue;
+          }
+        }
+        if (allowAboveRoot) {
+          if (res.length > 0)
+            res += '\\..';
+          else
+            res = '..';
+          lastSegmentLength = 2;
+        }
+      } else {
+        if (res.length > 0)
+          res += '\\' + path.slice(lastSlash + 1, i);
+        else
+          res = path.slice(lastSlash + 1, i);
+        lastSegmentLength = i - lastSlash - 1;
+      }
+      lastSlash = i;
+      dots = 0;
+    } else if (code === 46/*.*/ && dots !== -1) {
+      ++dots;
+    } else {
+      dots = -1;
+    }
+  }
+  return res;
+}
+
+// Resolves . and .. elements in a path with directory names
+function normalizeStringPosix(path, allowAboveRoot) {
+  var res = '';
+  var lastSegmentLength = 0;
+  var lastSlash = -1;
+  var dots = 0;
+  var code;
+  for (var i = 0; i <= path.length; ++i) {
+    if (i < path.length)
+      code = path.charCodeAt(i);
+    else if (code === 47/*/*/)
+      break;
+    else
+      code = 47/*/*/;
+    if (code === 47/*/*/) {
+      if (lastSlash === i - 1 || dots === 1) {
+        // NOOP
+      } else if (lastSlash !== i - 1 && dots === 2) {
+        if (res.length < 2 || lastSegmentLength !== 2 ||
+            res.charCodeAt(res.length - 1) !== 46/*.*/ ||
+            res.charCodeAt(res.length - 2) !== 46/*.*/) {
+          if (res.length > 2) {
+            const start = res.length - 1;
+            var j = start;
+            for (; j >= 0; --j) {
+              if (res.charCodeAt(j) === 47/*/*/)
+                break;
+            }
+            if (j !== start) {
+              if (j === -1) {
+                res = '';
+                lastSegmentLength = 0;
+              } else {
+                res = res.slice(0, j);
+                lastSegmentLength = j;
+              }
+              lastSlash = i;
+              dots = 0;
+              continue;
+            }
+          } else if (res.length === 2 || res.length === 1) {
+            res = '';
+            lastSegmentLength = 0;
+            lastSlash = i;
+            dots = 0;
+            continue;
+          }
+        }
+        if (allowAboveRoot) {
+          if (res.length > 0)
+            res += '/..';
+          else
+            res = '..';
+          lastSegmentLength = 2;
+        }
+      } else {
+        if (res.length > 0)
+          res += '/' + path.slice(lastSlash + 1, i);
+        else
+          res = path.slice(lastSlash + 1, i);
+        lastSegmentLength = i - lastSlash - 1;
+      }
+      lastSlash = i;
+      dots = 0;
+    } else if (code === 46/*.*/ && dots !== -1) {
+      ++dots;
+    } else {
+      dots = -1;
+    }
+  }
+  return res;
+}
+
+function _format(sep, pathObject) {
+  const dir = pathObject.dir || pathObject.root;
+  const base = pathObject.base ||
+    ((pathObject.name || '') + (pathObject.ext || ''));
+  if (!dir) {
+    return base;
+  }
+  if (dir === pathObject.root) {
+    return dir + base;
+  }
+  return dir + sep + base;
+}
+
+const win32 = {
+  // path.resolve([from ...], to)
+  resolve: function resolve() {
+    var resolvedDevice = '';
+    var resolvedTail = '';
+    var resolvedAbsolute = false;
+
+    for (var i = arguments.length - 1; i >= -1; i--) {
+      var path;
+      if (i >= 0) {
+        path = arguments[i];
+      } else if (!resolvedDevice) {
+        path = process.cwd();
+      } else {
+        // Windows has the concept of drive-specific current working
+        // directories. If we've resolved a drive letter but not yet an
+        // absolute path, get cwd for that drive, or the process cwd if
+        // the drive cwd is not available. We're sure the device is not
+        // a UNC path at this points, because UNC paths are always absolute.
+        path = process.env['=' + resolvedDevice] || process.cwd();
+
+        // Verify that a cwd was found and that it actually points
+        // to our drive. If not, default to the drive's root.
+        if (path === undefined ||
+            path.slice(0, 3).toLowerCase() !==
+              resolvedDevice.toLowerCase() + '\\') {
+          path = resolvedDevice + '\\';
+        }
+      }
+
+      assertPath(path);
+
+      // Skip empty entries
+      if (path.length === 0) {
+        continue;
+      }
+
+      var len = path.length;
+      var rootEnd = 0;
+      var code = path.charCodeAt(0);
+      var device = '';
+      var isAbsolute = false;
+
+      // Try to match a root
+      if (len > 1) {
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // Possible UNC root
+
+          // If we started with a separator, we know we at least have an
+          // absolute path of some kind (UNC or otherwise)
+          isAbsolute = true;
+
+          code = path.charCodeAt(1);
+          if (code === 47/*/*/ || code === 92/*\*/) {
+            // Matched double path separator at beginning
+            var j = 2;
+            var last = j;
+            // Match 1 or more non-path separators
+            for (; j < len; ++j) {
+              code = path.charCodeAt(j);
+              if (code === 47/*/*/ || code === 92/*\*/)
+                break;
+            }
+            if (j < len && j !== last) {
+              const firstPart = path.slice(last, j);
+              // Matched!
+              last = j;
+              // Match 1 or more path separators
+              for (; j < len; ++j) {
+                code = path.charCodeAt(j);
+                if (code !== 47/*/*/ && code !== 92/*\*/)
+                  break;
+              }
+              if (j < len && j !== last) {
+                // Matched!
+                last = j;
+                // Match 1 or more non-path separators
+                for (; j < len; ++j) {
+                  code = path.charCodeAt(j);
+                  if (code === 47/*/*/ || code === 92/*\*/)
+                    break;
+                }
+                if (j === len) {
+                  // We matched a UNC root only
+
+                  device = '\\\\' + firstPart + '\\' + path.slice(last);
+                  rootEnd = j;
+                } else if (j !== last) {
+                  // We matched a UNC root with leftovers
+
+                  device = '\\\\' + firstPart + '\\' + path.slice(last, j);
+                  rootEnd = j;
+                }
+              }
+            }
+          } else {
+            rootEnd = 1;
+          }
+        } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+                   (code >= 97/*a*/ && code <= 122/*z*/)) {
+          // Possible device root
+
+          code = path.charCodeAt(1);
+          if (path.charCodeAt(1) === 58/*:*/) {
+            device = path.slice(0, 2);
+            rootEnd = 2;
+            if (len > 2) {
+              code = path.charCodeAt(2);
+              if (code === 47/*/*/ || code === 92/*\*/) {
+                // Treat separator following drive name as an absolute path
+                // indicator
+                isAbsolute = true;
+                rootEnd = 3;
+              }
+            }
+          }
+        }
+      } else if (code === 47/*/*/ || code === 92/*\*/) {
+        // `path` contains just a path separator
+        rootEnd = 1;
+        isAbsolute = true;
+      }
+
+      if (device.length > 0 &&
+          resolvedDevice.length > 0 &&
+          device.toLowerCase() !== resolvedDevice.toLowerCase()) {
+        // This path points to another device so it is not applicable
+        continue;
+      }
+
+      if (resolvedDevice.length === 0 && device.length > 0) {
+        resolvedDevice = device;
+      }
+      if (!resolvedAbsolute) {
+        resolvedTail = path.slice(rootEnd) + '\\' + resolvedTail;
+        resolvedAbsolute = isAbsolute;
+      }
+
+      if (resolvedDevice.length > 0 && resolvedAbsolute) {
+        break;
+      }
+    }
+
+    // At this point the path should be resolved to a full absolute path,
+    // but handle relative paths to be safe (might happen when process.cwd()
+    // fails)
+
+    // Normalize the tail path
+    resolvedTail = normalizeStringWin32(resolvedTail, !resolvedAbsolute);
+
+    return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
+           '.';
+  },
+
+  normalize: function normalize(path) {
+    assertPath(path);
+    const len = path.length;
+    if (len === 0)
+      return '.';
+    var rootEnd = 0;
+    var code = path.charCodeAt(0);
+    var device;
+    var isAbsolute = false;
+
+    // Try to match a root
+    if (len > 1) {
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // Possible UNC root
+
+        // If we started with a separator, we know we at least have an absolute
+        // path of some kind (UNC or otherwise)
+        isAbsolute = true;
+
+        code = path.charCodeAt(1);
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // Matched double path separator at beginning
+          var j = 2;
+          var last = j;
+          // Match 1 or more non-path separators
+          for (; j < len; ++j) {
+            code = path.charCodeAt(j);
+            if (code === 47/*/*/ || code === 92/*\*/)
+              break;
+          }
+          if (j < len && j !== last) {
+            const firstPart = path.slice(last, j);
+            // Matched!
+            last = j;
+            // Match 1 or more path separators
+            for (; j < len; ++j) {
+              code = path.charCodeAt(j);
+              if (code !== 47/*/*/ && code !== 92/*\*/)
+                break;
+            }
+            if (j < len && j !== last) {
+              // Matched!
+              last = j;
+              // Match 1 or more non-path separators
+              for (; j < len; ++j) {
+                code = path.charCodeAt(j);
+                if (code === 47/*/*/ || code === 92/*\*/)
+                  break;
+              }
+              if (j === len) {
+                // We matched a UNC root only
+                // Return the normalized version of the UNC root since there
+                // is nothing left to process
+
+                return '\\\\' + firstPart + '\\' + path.slice(last) + '\\';
+              } else if (j !== last) {
+                // We matched a UNC root with leftovers
+
+                device = '\\\\' + firstPart + '\\' + path.slice(last, j);
+                rootEnd = j;
+              }
+            }
+          }
+        } else {
+          rootEnd = 1;
+        }
+      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+        // Possible device root
+
+        code = path.charCodeAt(1);
+        if (path.charCodeAt(1) === 58/*:*/) {
+          device = path.slice(0, 2);
+          rootEnd = 2;
+          if (len > 2) {
+            code = path.charCodeAt(2);
+            if (code === 47/*/*/ || code === 92/*\*/) {
+              // Treat separator following drive name as an absolute path
+              // indicator
+              isAbsolute = true;
+              rootEnd = 3;
+            }
+          }
+        }
+      }
+    } else if (code === 47/*/*/ || code === 92/*\*/) {
+      // `path` contains just a path separator, exit early to avoid unnecessary
+      // work
+      return '\\';
+    }
+
+    code = path.charCodeAt(len - 1);
+    var trailingSeparator = (code === 47/*/*/ || code === 92/*\*/);
+    var tail;
+    if (rootEnd < len)
+      tail = normalizeStringWin32(path.slice(rootEnd), !isAbsolute);
+    else
+      tail = '';
+    if (tail.length === 0 && !isAbsolute)
+      tail = '.';
+    if (tail.length > 0 && trailingSeparator)
+      tail += '\\';
+    if (device === undefined) {
+      if (isAbsolute) {
+        if (tail.length > 0)
+          return '\\' + tail;
+        else
+          return '\\';
+      } else if (tail.length > 0) {
+        return tail;
+      } else {
+        return '';
+      }
+    } else if (isAbsolute) {
+      if (tail.length > 0)
+        return device + '\\' + tail;
+      else
+        return device + '\\';
+    } else if (tail.length > 0) {
+      return device + tail;
+    } else {
+      return device;
+    }
+  },
+
+
+  isAbsolute: function isAbsolute(path) {
+    assertPath(path);
+    const len = path.length;
+    if (len === 0)
+      return false;
+    var code = path.charCodeAt(0);
+    if (code === 47/*/*/ || code === 92/*\*/) {
+      return true;
+    } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+               (code >= 97/*a*/ && code <= 122/*z*/)) {
+      // Possible device root
+
+      if (len > 2 && path.charCodeAt(1) === 58/*:*/) {
+        code = path.charCodeAt(2);
+        if (code === 47/*/*/ || code === 92/*\*/)
+          return true;
+      }
+    }
+    return false;
+  },
+
+
+  join: function join() {
+    if (arguments.length === 0)
+      return '.';
+
+    var joined;
+    var firstPart;
+    for (var i = 0; i < arguments.length; ++i) {
+      var arg = arguments[i];
+      assertPath(arg);
+      if (arg.length > 0) {
+        if (joined === undefined)
+          joined = firstPart = arg;
+        else
+          joined += '\\' + arg;
+      }
+    }
+
+    if (joined === undefined)
+      return '.';
+
+    // Make sure that the joined path doesn't start with two slashes, because
+    // normalize() will mistake it for an UNC path then.
+    //
+    // This step is skipped when it is very clear that the user actually
+    // intended to point at an UNC path. This is assumed when the first
+    // non-empty string arguments starts with exactly two slashes followed by
+    // at least one more non-slash character.
+    //
+    // Note that for normalize() to treat a path as an UNC path it needs to
+    // have at least 2 components, so we don't filter for that here.
+    // This means that the user can use join to construct UNC paths from
+    // a server name and a share name; for example:
+    //   path.join('//server', 'share') -> '\\\\server\\share\\')
+    //var firstPart = paths[0];
+    var needsReplace = true;
+    var slashCount = 0;
+    var code = firstPart.charCodeAt(0);
+    if (code === 47/*/*/ || code === 92/*\*/) {
+      ++slashCount;
+      const firstLen = firstPart.length;
+      if (firstLen > 1) {
+        code = firstPart.charCodeAt(1);
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          ++slashCount;
+          if (firstLen > 2) {
+            code = firstPart.charCodeAt(2);
+            if (code === 47/*/*/ || code === 92/*\*/)
+              ++slashCount;
+            else {
+              // We matched a UNC path in the first part
+              needsReplace = false;
+            }
+          }
+        }
+      }
+    }
+    if (needsReplace) {
+      // Find any more consecutive slashes we need to replace
+      for (; slashCount < joined.length; ++slashCount) {
+        code = joined.charCodeAt(slashCount);
+        if (code !== 47/*/*/ && code !== 92/*\*/)
+          break;
+      }
+
+      // Replace the slashes if needed
+      if (slashCount >= 2)
+        joined = '\\' + joined.slice(slashCount);
+    }
+
+    return win32.normalize(joined);
+  },
+
+
+  // It will solve the relative path from `from` to `to`, for instance:
+  //  from = 'C:\\orandea\\test\\aaa'
+  //  to = 'C:\\orandea\\impl\\bbb'
+  // The output of the function should be: '..\\..\\impl\\bbb'
+  relative: function relative(from, to) {
+    assertPath(from);
+    assertPath(to);
+
+    if (from === to)
+      return '';
+
+    var fromOrig = win32.resolve(from);
+    var toOrig = win32.resolve(to);
+
+    if (fromOrig === toOrig)
+      return '';
+
+    from = fromOrig.toLowerCase();
+    to = toOrig.toLowerCase();
+
+    if (from === to)
+      return '';
+
+    // Trim any leading backslashes
+    var fromStart = 0;
+    for (; fromStart < from.length; ++fromStart) {
+      if (from.charCodeAt(fromStart) !== 92/*\*/)
+        break;
+    }
+    // Trim trailing backslashes (applicable to UNC paths only)
+    var fromEnd = from.length;
+    for (; fromEnd - 1 > fromStart; --fromEnd) {
+      if (from.charCodeAt(fromEnd - 1) !== 92/*\*/)
+        break;
+    }
+    var fromLen = (fromEnd - fromStart);
+
+    // Trim any leading backslashes
+    var toStart = 0;
+    for (; toStart < to.length; ++toStart) {
+      if (to.charCodeAt(toStart) !== 92/*\*/)
+        break;
+    }
+    // Trim trailing backslashes (applicable to UNC paths only)
+    var toEnd = to.length;
+    for (; toEnd - 1 > toStart; --toEnd) {
+      if (to.charCodeAt(toEnd - 1) !== 92/*\*/)
+        break;
+    }
+    var toLen = (toEnd - toStart);
+
+    // Compare paths to find the longest common path from root
+    var length = (fromLen < toLen ? fromLen : toLen);
+    var lastCommonSep = -1;
+    var i = 0;
+    for (; i <= length; ++i) {
+      if (i === length) {
+        if (toLen > length) {
+          if (to.charCodeAt(toStart + i) === 92/*\*/) {
+            // We get here if `from` is the exact base path for `to`.
+            // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
+            return toOrig.slice(toStart + i + 1);
+          } else if (i === 2) {
+            // We get here if `from` is the device root.
+            // For example: from='C:\\'; to='C:\\foo'
+            return toOrig.slice(toStart + i);
+          }
+        }
+        if (fromLen > length) {
+          if (from.charCodeAt(fromStart + i) === 92/*\*/) {
+            // We get here if `to` is the exact base path for `from`.
+            // For example: from='C:\\foo\\bar'; to='C:\\foo'
+            lastCommonSep = i;
+          } else if (i === 2) {
+            // We get here if `to` is the device root.
+            // For example: from='C:\\foo\\bar'; to='C:\\'
+            lastCommonSep = 3;
+          }
+        }
+        break;
+      }
+      var fromCode = from.charCodeAt(fromStart + i);
+      var toCode = to.charCodeAt(toStart + i);
+      if (fromCode !== toCode)
+        break;
+      else if (fromCode === 92/*\*/)
+        lastCommonSep = i;
+    }
+
+    // We found a mismatch before the first common path separator was seen, so
+    // return the original `to`.
+    if (i !== length && lastCommonSep === -1) {
+      return toOrig;
+    }
+
+    var out = '';
+    if (lastCommonSep === -1)
+      lastCommonSep = 0;
+    // Generate the relative path based on the path difference between `to` and
+    // `from`
+    for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+      if (i === fromEnd || from.charCodeAt(i) === 92/*\*/) {
+        if (out.length === 0)
+          out += '..';
+        else
+          out += '\\..';
+      }
+    }
+
+    // Lastly, append the rest of the destination (`to`) path that comes after
+    // the common path parts
+    if (out.length > 0)
+      return out + toOrig.slice(toStart + lastCommonSep, toEnd);
+    else {
+      toStart += lastCommonSep;
+      if (toOrig.charCodeAt(toStart) === 92/*\*/)
+        ++toStart;
+      return toOrig.slice(toStart, toEnd);
+    }
+  },
+
+
+  toNamespacedPath: function toNamespacedPath(path) {
+    // Note: this will *probably* throw somewhere.
+    if (typeof path !== 'string')
+      return path;
+
+    if (path.length === 0) {
+      return '';
+    }
+
+    const resolvedPath = win32.resolve(path);
+
+    if (resolvedPath.length >= 3) {
+      var code = resolvedPath.charCodeAt(0);
+      if (code === 92/*\*/) {
+        // Possible UNC root
+
+        if (resolvedPath.charCodeAt(1) === 92/*\*/) {
+          code = resolvedPath.charCodeAt(2);
+          if (code !== 63/*?*/ && code !== 46/*.*/) {
+            // Matched non-long UNC root, convert the path to a long UNC path
+            return '\\\\?\\UNC\\' + resolvedPath.slice(2);
+          }
+        }
+      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+        // Possible device root
+
+        if (resolvedPath.charCodeAt(1) === 58/*:*/ &&
+            resolvedPath.charCodeAt(2) === 92/*\*/) {
+          // Matched device root, convert the path to a long UNC path
+          return '\\\\?\\' + resolvedPath;
+        }
+      }
+    }
+
+    return path;
+  },
+
+  dirname: function dirname(path) {
+    assertPath(path);
+    const len = path.length;
+    if (len === 0)
+      return '.';
+    var rootEnd = -1;
+    var end = -1;
+    var matchedSlash = true;
+    var offset = 0;
+    var code = path.charCodeAt(0);
+
+    // Try to match a root
+    if (len > 1) {
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // Possible UNC root
+
+        rootEnd = offset = 1;
+
+        code = path.charCodeAt(1);
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // Matched double path separator at beginning
+          var j = 2;
+          var last = j;
+          // Match 1 or more non-path separators
+          for (; j < len; ++j) {
+            code = path.charCodeAt(j);
+            if (code === 47/*/*/ || code === 92/*\*/)
+              break;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more path separators
+            for (; j < len; ++j) {
+              code = path.charCodeAt(j);
+              if (code !== 47/*/*/ && code !== 92/*\*/)
+                break;
+            }
+            if (j < len && j !== last) {
+              // Matched!
+              last = j;
+              // Match 1 or more non-path separators
+              for (; j < len; ++j) {
+                code = path.charCodeAt(j);
+                if (code === 47/*/*/ || code === 92/*\*/)
+                  break;
+              }
+              if (j === len) {
+                // We matched a UNC root only
+                return path;
+              }
+              if (j !== last) {
+                // We matched a UNC root with leftovers
+
+                // Offset by 1 to include the separator after the UNC root to
+                // treat it as a "normal root" on top of a (UNC) root
+                rootEnd = offset = j + 1;
+              }
+            }
+          }
+        }
+      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+        // Possible device root
+
+        code = path.charCodeAt(1);
+        if (path.charCodeAt(1) === 58/*:*/) {
+          rootEnd = offset = 2;
+          if (len > 2) {
+            code = path.charCodeAt(2);
+            if (code === 47/*/*/ || code === 92/*\*/)
+              rootEnd = offset = 3;
+          }
+        }
+      }
+    } else if (code === 47/*/*/ || code === 92/*\*/) {
+      // `path` contains just a path separator, exit early to avoid
+      // unnecessary work
+      return path;
+    }
+
+    for (var i = len - 1; i >= offset; --i) {
+      code = path.charCodeAt(i);
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        if (!matchedSlash) {
+          end = i;
+          break;
+        }
+      } else {
+        // We saw the first non-path separator
+        matchedSlash = false;
+      }
+    }
+
+    if (end === -1) {
+      if (rootEnd === -1)
+        return '.';
+      else
+        end = rootEnd;
+    }
+    return path.slice(0, end);
+  },
+
+
+  basename: function basename(path, ext) {
+    if (ext !== undefined && typeof ext !== 'string')
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
+    assertPath(path);
+    var start = 0;
+    var end = -1;
+    var matchedSlash = true;
+    var i;
+
+    // Check for a drive letter prefix so as not to mistake the following
+    // path separator as an extra separator at the end of the path that can be
+    // disregarded
+    if (path.length >= 2) {
+      const drive = path.charCodeAt(0);
+      if ((drive >= 65/*A*/ && drive <= 90/*Z*/) ||
+          (drive >= 97/*a*/ && drive <= 122/*z*/)) {
+        if (path.charCodeAt(1) === 58/*:*/)
+          start = 2;
+      }
+    }
+
+    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+      if (ext.length === path.length && ext === path)
+        return '';
+      var extIdx = ext.length - 1;
+      var firstNonSlashEnd = -1;
+      for (i = path.length - 1; i >= start; --i) {
+        const code = path.charCodeAt(i);
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else {
+          if (firstNonSlashEnd === -1) {
+            // We saw the first non-path separator, remember this index in case
+            // we need it if the extension ends up not matching
+            matchedSlash = false;
+            firstNonSlashEnd = i + 1;
+          }
+          if (extIdx >= 0) {
+            // Try to match the explicit extension
+            if (code === ext.charCodeAt(extIdx)) {
+              if (--extIdx === -1) {
+                // We matched the extension, so mark this as the end of our path
+                // component
+                end = i;
+              }
+            } else {
+              // Extension does not match, so our result is the entire path
+              // component
+              extIdx = -1;
+              end = firstNonSlashEnd;
+            }
+          }
+        }
+      }
+
+      if (start === end)
+        end = firstNonSlashEnd;
+      else if (end === -1)
+        end = path.length;
+      return path.slice(start, end);
+    } else {
+      for (i = path.length - 1; i >= start; --i) {
+        const code = path.charCodeAt(i);
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else if (end === -1) {
+          // We saw the first non-path separator, mark this as the end of our
+          // path component
+          matchedSlash = false;
+          end = i + 1;
+        }
+      }
+
+      if (end === -1)
+        return '';
+      return path.slice(start, end);
+    }
+  },
+
+
+  extname: function extname(path) {
+    assertPath(path);
+    var start = 0;
+    var startDot = -1;
+    var startPart = 0;
+    var end = -1;
+    var matchedSlash = true;
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    var preDotState = 0;
+
+    // Check for a drive letter prefix so as not to mistake the following
+    // path separator as an extra separator at the end of the path that can be
+    // disregarded
+    if (path.length >= 2) {
+      const code = path.charCodeAt(0);
+      if (path.charCodeAt(1) === 58/*:*/ &&
+          ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+           (code >= 97/*a*/ && code <= 122/*z*/))) {
+        start = startPart = 2;
+      }
+    }
+
+    for (var i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === 46/*.*/) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (startDot === -1 ||
+        end === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+         startDot === end - 1 &&
+         startDot === startPart + 1)) {
+      return '';
+    }
+    return path.slice(startDot, end);
+  },
+
+
+  format: function format(pathObject) {
+    if (pathObject === null || typeof pathObject !== 'object') {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
+                                 pathObject);
+    }
+    return _format('\\', pathObject);
+  },
+
+
+  parse: function parse(path) {
+    assertPath(path);
+
+    var ret = { root: '', dir: '', base: '', ext: '', name: '' };
+    if (path.length === 0)
+      return ret;
+
+    var len = path.length;
+    var rootEnd = 0;
+    var code = path.charCodeAt(0);
+
+    // Try to match a root
+    if (len > 1) {
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // Possible UNC root
+
+        code = path.charCodeAt(1);
+        rootEnd = 1;
+        if (code === 47/*/*/ || code === 92/*\*/) {
+          // Matched double path separator at beginning
+          var j = 2;
+          var last = j;
+          // Match 1 or more non-path separators
+          for (; j < len; ++j) {
+            code = path.charCodeAt(j);
+            if (code === 47/*/*/ || code === 92/*\*/)
+              break;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more path separators
+            for (; j < len; ++j) {
+              code = path.charCodeAt(j);
+              if (code !== 47/*/*/ && code !== 92/*\*/)
+                break;
+            }
+            if (j < len && j !== last) {
+              // Matched!
+              last = j;
+              // Match 1 or more non-path separators
+              for (; j < len; ++j) {
+                code = path.charCodeAt(j);
+                if (code === 47/*/*/ || code === 92/*\*/)
+                  break;
+              }
+              if (j === len) {
+                // We matched a UNC root only
+
+                rootEnd = j;
+              } else if (j !== last) {
+                // We matched a UNC root with leftovers
+
+                rootEnd = j + 1;
+              }
+            }
+          }
+        }
+      } else if ((code >= 65/*A*/ && code <= 90/*Z*/) ||
+                 (code >= 97/*a*/ && code <= 122/*z*/)) {
+        // Possible device root
+
+        code = path.charCodeAt(1);
+        if (path.charCodeAt(1) === 58/*:*/) {
+          rootEnd = 2;
+          if (len > 2) {
+            code = path.charCodeAt(2);
+            if (code === 47/*/*/ || code === 92/*\*/) {
+              if (len === 3) {
+                // `path` contains just a drive root, exit early to avoid
+                // unnecessary work
+                ret.root = ret.dir = path;
+                return ret;
+              }
+              rootEnd = 3;
+            }
+          } else {
+            // `path` contains just a drive root, exit early to avoid
+            // unnecessary work
+            ret.root = ret.dir = path;
+            return ret;
+          }
+        }
+      }
+    } else if (code === 47/*/*/ || code === 92/*\*/) {
+      // `path` contains just a path separator, exit early to avoid
+      // unnecessary work
+      ret.root = ret.dir = path;
+      return ret;
+    }
+
+    if (rootEnd > 0)
+      ret.root = path.slice(0, rootEnd);
+
+    var startDot = -1;
+    var startPart = rootEnd;
+    var end = -1;
+    var matchedSlash = true;
+    var i = path.length - 1;
+
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    var preDotState = 0;
+
+    // Get non-dir info
+    for (; i >= rootEnd; --i) {
+      code = path.charCodeAt(i);
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === 46/*.*/) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (startDot === -1 ||
+        end === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+         startDot === end - 1 &&
+         startDot === startPart + 1)) {
+      if (end !== -1) {
+        ret.base = ret.name = path.slice(startPart, end);
+      }
+    } else {
+      ret.name = path.slice(startPart, startDot);
+      ret.base = path.slice(startPart, end);
+      ret.ext = path.slice(startDot, end);
+    }
+
+    // If the directory is the root, use the entire root as the `dir` including
+    // the trailing slash if any (`C:\abc` -> `C:\`). Otherwise, strip out the
+    // trailing slash (`C:\abc\def` -> `C:\abc`).
+    if (startPart > 0 && startPart !== rootEnd)
+      ret.dir = path.slice(0, startPart - 1);
+    else
+      ret.dir = ret.root;
+
+    return ret;
+  },
+
+
+  sep: '\\',
+  delimiter: ';',
+  win32: null,
+  posix: null
 };
+
+
+const posix = {
+  // path.resolve([from ...], to)
+  resolve: function resolve() {
+    var resolvedPath = '';
+    var resolvedAbsolute = false;
+    var cwd;
+
+    for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+      var path;
+      if (i >= 0)
+        path = arguments[i];
+      else {
+        if (cwd === undefined)
+          cwd = process.cwd();
+        path = cwd;
+      }
+
+      assertPath(path);
+
+      // Skip empty entries
+      if (path.length === 0) {
+        continue;
+      }
+
+      resolvedPath = path + '/' + resolvedPath;
+      resolvedAbsolute = path.charCodeAt(0) === 47/*/*/;
+    }
+
+    // At this point the path should be resolved to a full absolute path, but
+    // handle relative paths to be safe (might happen when process.cwd() fails)
+
+    // Normalize the path
+    resolvedPath = normalizeStringPosix(resolvedPath, !resolvedAbsolute);
+
+    if (resolvedAbsolute) {
+      if (resolvedPath.length > 0)
+        return '/' + resolvedPath;
+      else
+        return '/';
+    } else if (resolvedPath.length > 0) {
+      return resolvedPath;
+    } else {
+      return '.';
+    }
+  },
+
+
+  normalize: function normalize(path) {
+    assertPath(path);
+
+    if (path.length === 0)
+      return '.';
+
+    const isAbsolute = path.charCodeAt(0) === 47/*/*/;
+    const trailingSeparator = path.charCodeAt(path.length - 1) === 47/*/*/;
+
+    // Normalize the path
+    path = normalizeStringPosix(path, !isAbsolute);
+
+    if (path.length === 0 && !isAbsolute)
+      path = '.';
+    if (path.length > 0 && trailingSeparator)
+      path += '/';
+
+    if (isAbsolute)
+      return '/' + path;
+    return path;
+  },
+
+
+  isAbsolute: function isAbsolute(path) {
+    assertPath(path);
+    return path.length > 0 && path.charCodeAt(0) === 47/*/*/;
+  },
+
+
+  join: function join() {
+    if (arguments.length === 0)
+      return '.';
+    var joined;
+    for (var i = 0; i < arguments.length; ++i) {
+      var arg = arguments[i];
+      assertPath(arg);
+      if (arg.length > 0) {
+        if (joined === undefined)
+          joined = arg;
+        else
+          joined += '/' + arg;
+      }
+    }
+    if (joined === undefined)
+      return '.';
+    return posix.normalize(joined);
+  },
+
+
+  relative: function relative(from, to) {
+    assertPath(from);
+    assertPath(to);
+
+    if (from === to)
+      return '';
+
+    from = posix.resolve(from);
+    to = posix.resolve(to);
+
+    if (from === to)
+      return '';
+
+    // Trim any leading backslashes
+    var fromStart = 1;
+    for (; fromStart < from.length; ++fromStart) {
+      if (from.charCodeAt(fromStart) !== 47/*/*/)
+        break;
+    }
+    var fromEnd = from.length;
+    var fromLen = (fromEnd - fromStart);
+
+    // Trim any leading backslashes
+    var toStart = 1;
+    for (; toStart < to.length; ++toStart) {
+      if (to.charCodeAt(toStart) !== 47/*/*/)
+        break;
+    }
+    var toEnd = to.length;
+    var toLen = (toEnd - toStart);
+
+    // Compare paths to find the longest common path from root
+    var length = (fromLen < toLen ? fromLen : toLen);
+    var lastCommonSep = -1;
+    var i = 0;
+    for (; i <= length; ++i) {
+      if (i === length) {
+        if (toLen > length) {
+          if (to.charCodeAt(toStart + i) === 47/*/*/) {
+            // We get here if `from` is the exact base path for `to`.
+            // For example: from='/foo/bar'; to='/foo/bar/baz'
+            return to.slice(toStart + i + 1);
+          } else if (i === 0) {
+            // We get here if `from` is the root
+            // For example: from='/'; to='/foo'
+            return to.slice(toStart + i);
+          }
+        } else if (fromLen > length) {
+          if (from.charCodeAt(fromStart + i) === 47/*/*/) {
+            // We get here if `to` is the exact base path for `from`.
+            // For example: from='/foo/bar/baz'; to='/foo/bar'
+            lastCommonSep = i;
+          } else if (i === 0) {
+            // We get here if `to` is the root.
+            // For example: from='/foo'; to='/'
+            lastCommonSep = 0;
+          }
+        }
+        break;
+      }
+      var fromCode = from.charCodeAt(fromStart + i);
+      var toCode = to.charCodeAt(toStart + i);
+      if (fromCode !== toCode)
+        break;
+      else if (fromCode === 47/*/*/)
+        lastCommonSep = i;
+    }
+
+    var out = '';
+    // Generate the relative path based on the path difference between `to`
+    // and `from`
+    for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+      if (i === fromEnd || from.charCodeAt(i) === 47/*/*/) {
+        if (out.length === 0)
+          out += '..';
+        else
+          out += '/..';
+      }
+    }
+
+    // Lastly, append the rest of the destination (`to`) path that comes after
+    // the common path parts
+    if (out.length > 0)
+      return out + to.slice(toStart + lastCommonSep);
+    else {
+      toStart += lastCommonSep;
+      if (to.charCodeAt(toStart) === 47/*/*/)
+        ++toStart;
+      return to.slice(toStart);
+    }
+  },
+
+
+  toNamespacedPath: function toNamespacedPath(path) {
+    // Non-op on posix systems
+    return path;
+  },
+
+  dirname: function dirname(path) {
+    assertPath(path);
+    if (path.length === 0)
+      return '.';
+    var code = path.charCodeAt(0);
+    var hasRoot = (code === 47/*/*/);
+    var end = -1;
+    var matchedSlash = true;
+    for (var i = path.length - 1; i >= 1; --i) {
+      code = path.charCodeAt(i);
+      if (code === 47/*/*/) {
+        if (!matchedSlash) {
+          end = i;
+          break;
+        }
+      } else {
+        // We saw the first non-path separator
+        matchedSlash = false;
+      }
+    }
+
+    if (end === -1)
+      return hasRoot ? '/' : '.';
+    if (hasRoot && end === 1)
+      return '//';
+    return path.slice(0, end);
+  },
+
+
+  basename: function basename(path, ext) {
+    if (ext !== undefined && typeof ext !== 'string')
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
+    assertPath(path);
+
+    var start = 0;
+    var end = -1;
+    var matchedSlash = true;
+    var i;
+
+    if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+      if (ext.length === path.length && ext === path)
+        return '';
+      var extIdx = ext.length - 1;
+      var firstNonSlashEnd = -1;
+      for (i = path.length - 1; i >= 0; --i) {
+        const code = path.charCodeAt(i);
+        if (code === 47/*/*/) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else {
+          if (firstNonSlashEnd === -1) {
+            // We saw the first non-path separator, remember this index in case
+            // we need it if the extension ends up not matching
+            matchedSlash = false;
+            firstNonSlashEnd = i + 1;
+          }
+          if (extIdx >= 0) {
+            // Try to match the explicit extension
+            if (code === ext.charCodeAt(extIdx)) {
+              if (--extIdx === -1) {
+                // We matched the extension, so mark this as the end of our path
+                // component
+                end = i;
+              }
+            } else {
+              // Extension does not match, so our result is the entire path
+              // component
+              extIdx = -1;
+              end = firstNonSlashEnd;
+            }
+          }
+        }
+      }
+
+      if (start === end)
+        end = firstNonSlashEnd;
+      else if (end === -1)
+        end = path.length;
+      return path.slice(start, end);
+    } else {
+      for (i = path.length - 1; i >= 0; --i) {
+        if (path.charCodeAt(i) === 47/*/*/) {
+          // If we reached a path separator that was not part of a set of path
+          // separators at the end of the string, stop now
+          if (!matchedSlash) {
+            start = i + 1;
+            break;
+          }
+        } else if (end === -1) {
+          // We saw the first non-path separator, mark this as the end of our
+          // path component
+          matchedSlash = false;
+          end = i + 1;
+        }
+      }
+
+      if (end === -1)
+        return '';
+      return path.slice(start, end);
+    }
+  },
+
+
+  extname: function extname(path) {
+    assertPath(path);
+    var startDot = -1;
+    var startPart = 0;
+    var end = -1;
+    var matchedSlash = true;
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    var preDotState = 0;
+    for (var i = path.length - 1; i >= 0; --i) {
+      const code = path.charCodeAt(i);
+      if (code === 47/*/*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === 46/*.*/) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (startDot === -1 ||
+        end === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+         startDot === end - 1 &&
+         startDot === startPart + 1)) {
+      return '';
+    }
+    return path.slice(startDot, end);
+  },
+
+
+  format: function format(pathObject) {
+    if (pathObject === null || typeof pathObject !== 'object') {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
+                                 pathObject);
+    }
+    return _format('/', pathObject);
+  },
+
+
+  parse: function parse(path) {
+    assertPath(path);
+
+    var ret = { root: '', dir: '', base: '', ext: '', name: '' };
+    if (path.length === 0)
+      return ret;
+    var code = path.charCodeAt(0);
+    var isAbsolute = (code === 47/*/*/);
+    var start;
+    if (isAbsolute) {
+      ret.root = '/';
+      start = 1;
+    } else {
+      start = 0;
+    }
+    var startDot = -1;
+    var startPart = 0;
+    var end = -1;
+    var matchedSlash = true;
+    var i = path.length - 1;
+
+    // Track the state of characters (if any) we see before our first dot and
+    // after any path separator we find
+    var preDotState = 0;
+
+    // Get non-dir info
+    for (; i >= start; --i) {
+      code = path.charCodeAt(i);
+      if (code === 47/*/*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          startPart = i + 1;
+          break;
+        }
+        continue;
+      }
+      if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // extension
+        matchedSlash = false;
+        end = i + 1;
+      }
+      if (code === 46/*.*/) {
+        // If this is our first dot, mark it as the start of our extension
+        if (startDot === -1)
+          startDot = i;
+        else if (preDotState !== 1)
+          preDotState = 1;
+      } else if (startDot !== -1) {
+        // We saw a non-dot and non-path separator before our dot, so we should
+        // have a good chance at having a non-empty extension
+        preDotState = -1;
+      }
+    }
+
+    if (startDot === -1 ||
+        end === -1 ||
+        // We saw a non-dot character immediately before the dot
+        preDotState === 0 ||
+        // The (right-most) trimmed path component is exactly '..'
+        (preDotState === 1 &&
+         startDot === end - 1 &&
+         startDot === startPart + 1)) {
+      if (end !== -1) {
+        if (startPart === 0 && isAbsolute)
+          ret.base = ret.name = path.slice(1, end);
+        else
+          ret.base = ret.name = path.slice(startPart, end);
+      }
+    } else {
+      if (startPart === 0 && isAbsolute) {
+        ret.name = path.slice(1, startDot);
+        ret.base = path.slice(1, end);
+      } else {
+        ret.name = path.slice(startPart, startDot);
+        ret.base = path.slice(startPart, end);
+      }
+      ret.ext = path.slice(startDot, end);
+    }
+
+    if (startPart > 0)
+      ret.dir = path.slice(0, startPart - 1);
+    else if (isAbsolute)
+      ret.dir = '/';
+
+    return ret;
+  },
+
+
+  sep: '/',
+  delimiter: ':',
+  win32: null,
+  posix: null
+};
+
+
+posix.win32 = win32.win32 = win32;
+posix.posix = win32.posix = posix;
+
+// Legacy internal API, docs-only deprecated: DEP0080
+win32._makeLong = win32.toNamespacedPath;
+posix._makeLong = posix.toNamespacedPath;
+
+// process.platform is always "UnrealJS" on UnrealJS. Use builtin to query platform
+if (JavascriptLibrary.GetPlatformName() == "Windows")
+  module.exports = win32;
+else
+  module.exports = posix;

--- a/Content/Scripts/polyfill/timers.js
+++ b/Content/Scripts/polyfill/timers.js
@@ -38,7 +38,8 @@
         argv: [],
         argc: 0,
         platform: 'UnrealJS',
-        env: {}
+        env: {},
+        cwd: $cwd
     }
 
     Root.OnTick.Add(root)

--- a/Source/V8/Private/JavascriptIsolate_Private.cpp
+++ b/Source/V8/Private/JavascriptIsolate_Private.cpp
@@ -1057,6 +1057,12 @@ public:
 	{
 		FIsolateHelper I(isolate_);
 
+		auto fileManagerCwd = [](const FunctionCallbackInfo<Value>& info)
+		{
+			info.GetReturnValue().Set(V8_String(info.GetIsolate(), IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(L"."))); // FPaths::ProjectDir()
+        };
+		global_templ->Set(I.Keyword("$cwd"), I.FunctionTemplate(fileManagerCwd));
+
 #if WITH_EDITOR
 		auto exec_editor = [](const FunctionCallbackInfo<Value>& info) 
 		{


### PR DESCRIPTION
I am using Unreal.js with TypeScript. I would like to use source maps, which allow exception traces to be displayed with TypeScript filenames and line numbers. The standard way to do this is [node-source-map-support](https://github.com/evanw/node-source-map-support) from npm. `node-source-map-support` relies on Node functions which are not present in Unreal.js. This PR adds them.

**The missing NPM functions required by source-map-support are:**

* `fs.existsSync`
* `path.trim`
* `path.dirname`
* `path.resolve`
* In addition, source-map-support needs `fs.readFileSync` and `fs.existsSync` to support `file://` URLs as arguments.

**What this Pull Request does:**

* Modified `fs.readFileSync` to parse `file://` URLs
* Added `fs.existsSync` (with `file://` support) to `fs`
* Added the entire `path` module from the NodeJS source, tag `v9.2.0`
* Added the entire `internal/errors` module from the NodeJS source (required to support the new `path.js`)
* Added `process.cwd()` (required to support the new `path.js`)

**Possible problems with this pull request:**

* `path.js` and `internal/errors.js` are bound by the JoyEnt license for NodeJS. Accepting this PR would therefore require a modification to your license.
* I am not sure if I handled `process.cwd` properly. The way I added it was by exporting a function from C++ named `$cwd` and moving it into `process` in `timers.js`. Perhaps the function should have gone in `JavascriptLibrary` instead.
* I am not sure if I handled `existsSync` properly. My new `existsSync` uses `JavascriptLibrary.FileExists` whereas the existing `readFileSync` uses `Context.ReadScriptFile`. This means that when a relative path is given, `existsSync` will load files relative to `process.cwd`, whereas `readFileSync` will check multiple locations and therefore successfully load files which `existSync` claims does not exist.

I think the JoyEnt license is probably worth it. In the long run, I believe it would be good to move all of the Node core libraries into Unreal.JS so that npm modules can be used without worrying about Node compatibility.

If this PR is accepted, I can add a document to the wiki explaining how to configure `node-source-map-support`.