### PR TITLE
Linux Compilation Errors

### DIFF
--- a/Source/V8/Private/JavascriptContext_Private.cpp
+++ b/Source/V8/Private/JavascriptContext_Private.cpp
@@ -1151,14 +1151,14 @@ public:
 					auto Function1 = FuncMap->Get(context, I.Keyword("prector")).ToLocalChecked();
 
 					auto ProxyFuncMap = ProxyFunctions->ToObject(context).ToLocalChecked();
-					ProxyFuncMap->Set(context, I.Keyword("ctor"), Function0);
-					ProxyFuncMap->Set(context, I.Keyword("prector"), Function1);
+					auto ret0 = ProxyFuncMap->Set(context, I.Keyword("ctor"), Function0);
+					auto ret1 = ProxyFuncMap->Set(context, I.Keyword("prector"), Function1);
 				}
 			}
 			Context->Environment->PublicExportUClass(Class);
 
 			auto aftr_v8_template = Context->ExportObject(Class);
-			aftr_v8_template->ToObject(context).ToLocalChecked()->Set(context, I.Keyword("proxy"), ProxyFunctions);
+			auto ret = aftr_v8_template->ToObject(context).ToLocalChecked()->Set(context, I.Keyword("proxy"), ProxyFunctions);
 
 			Class->GetDefaultObject(true);
 
@@ -1303,7 +1303,7 @@ public:
 			Context->Environment->PublicExportStruct(Struct);
 
 			auto aftr_v8_template = Context->ExportObject(Struct);
-			aftr_v8_template->ToObject(context).ToLocalChecked()->Set(context, I.Keyword("proxy"), ProxyFunctions);
+			auto ret = aftr_v8_template->ToObject(context).ToLocalChecked()->Set(context, I.Keyword("proxy"), ProxyFunctions);
 			auto end = FPlatformTime::Seconds();
 			UE_LOG(Javascript, Warning, TEXT("Rebind UStruct(%s) Elapsed: %.6f"), *Struct->GetName(), end - start);
 #endif

--- a/Source/V8/Private/JavascriptContext_Private.h
+++ b/Source/V8/Private/JavascriptContext_Private.h
@@ -22,7 +22,6 @@ struct FJavascriptContext : TSharedFromThis<FJavascriptContext>
 			: Instance(InInstance)
 			, Value(MoveTemp(InValue))
 		{}
-		FExportedStructMemoryInfo(const FExportedStructMemoryInfo& Other) = default;
 		FExportedStructMemoryInfo(FExportedStructMemoryInfo&& TempOther) = default;
 
 		~FExportedStructMemoryInfo()

--- a/Source/V8/Private/JavascriptIsolate_Private.cpp
+++ b/Source/V8/Private/JavascriptIsolate_Private.cpp
@@ -1,4 +1,4 @@
-﻿PRAGMA_DISABLE_SHADOW_VARIABLE_WARNINGS
+PRAGMA_DISABLE_SHADOW_VARIABLE_WARNINGS
 
 #ifndef THIRD_PARTY_INCLUDES_START
 #	define THIRD_PARTY_INCLUDES_START
@@ -1186,7 +1186,7 @@ public:
 				if (!function.IsEmpty())
 				{
 					auto isolate = info.GetIsolate();
-					function->Call(isolate->GetCurrentContext(), info.This(), 0, nullptr);
+					auto ret = function->Call(isolate->GetCurrentContext(), info.This(), 0, nullptr);
 				}
 			}
 		};
@@ -1203,7 +1203,7 @@ public:
 				auto function = info[1].As<Function>();
 				if (!function.IsEmpty())
 				{
-					function->Call(isolate->GetCurrentContext(), info.This(), 0, nullptr);
+					auto ret = function->Call(isolate->GetCurrentContext(), info.This(), 0, nullptr);
 				}
 			}
 		};

--- a/Source/V8/V8.Build.cs
+++ b/Source/V8/V8.Build.cs
@@ -36,8 +36,10 @@ public class V8 : ModuleRules
     public V8(ReadOnlyTargetRules Target) : base(Target)
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bLegacyPublicIncludePaths = false;
-        ShadowVariableWarningLevel = WarningLevel.Error;
+        PrivatePCHHeaderFile = "Private/V8PCH.h";
+
+        ShadowVariableWarningLevel = WarningLevel.Warning;
+        
         PrivateIncludePaths.AddRange(new string[]
         {
             Path.Combine(ThirdPartyPath, "v8", "include")


### PR DESCRIPTION
As of Unreal 4.21 you must explicitly declare your PCH file,  and as of 4.24 you need to configure a few flags in the modules build.cs in order to use PCH files as well as suppress shadow variable warnings. This commit includes those changes to the V8.Build.cs to ensure that the V8PCH.h file is used when compiling the V8 module.

Additionally, I was unable to suppress the -Wunused-return warning as error so changes where made to store the return value in those cases.

Finally,  `FExportedStructMemoryInfo` would throw an error detailing how the copy constructor was deleted, so I removed the attempt to default it. It appears as if the Global context in v8 is a move only type so removing the copy constructor suppress the error.

Until issue #53 is resolved I am unable to link, however all of these changes allow me to compile on Linux against 4.24.1.