### PR TITLE
Changee module type from Editor to Runtime

### DIFF
--- a/UnrealJS.uplugin
+++ b/UnrealJS.uplugin
@@ -14,25 +14,25 @@
   "Modules": [
     {
       "Name": "V8",
-      "Type": "Editor",
+      "Type": "Runtime",
       "LoadingPhase": "PreDefault",
       "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "Linux", "Android", "IOS" ]
     },
     {
       "Name": "JavascriptUMG",
-      "Type": "Editor",
+      "Type": "Runtime",
       "LoadingPhase": "PreDefault",
       "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "Linux", "Android", "IOS" ]
     },
     {
       "Name": "JavascriptHttp",
-      "Type": "Editor",
+      "Type": "Runtime",
       "LoadingPhase": "PreDefault",
       "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "Linux", "Android", "IOS" ]
     },
     {
       "Name": "JavascriptWebSocket",
-      "Type": "Editor",
+      "Type": "Runtime",
       "LoadingPhase": "PreDefault",
       "WhitelistPlatforms": [ "Win64" ]
     },


### PR DESCRIPTION
Hello,
Thank you for making this plugin, it is doing a lot of great things.

When I updated the engine version of the project using this plugin to 4.25, the following phenomenon occurred.

+ Crash when launched with 'Standalone Game'
+ Project packaging fails

The phenomenon is reproduced in the following project

This project is as simple as referencing a V8 module in C ++.

https://github.com/ayumax/UnrealJS425

### Crash report when launched in'Standalone Game'
![crash](https://user-images.githubusercontent.com/8191970/97012743-27f1f700-1583-11eb-9d4f-ca090ae74270.png)

### Error log when packaging

```
UATHelper: Packaging (Windows (64-bit)):   ERROR: Missing precompiled manifest for 'V8'. This module was most likely not flagged for being included in a precompiled build - set 'PrecompileForTargets = PrecompileTargetsType.Any;' in V8.build.cs to override.
PackagingResults: Error: Missing precompiled manifest for 'V8'. This module was most likely not flagged for being included in a precompiled build - set 'PrecompileForTargets = PrecompileTargetsType.Any;' in V8.build.cs to override.
UATHelper: Packaging (Windows (64-bit)): Took 14.6121957s to run UnrealBuildTool.exe, ExitCode=6
UATHelper: Packaging (Windows (64-bit)): UnrealBuildTool failed. See log for more details. (C:\Users\ayuma\AppData\Roaming\Unreal Engine\AutomationTool\Logs\C+Program+Files+Epic+Games+UE_4.25\UBT-UnrealJS425-Win64-Development.txt)
UATHelper: Packaging (Windows (64-bit)): AutomationTool exiting with ExitCode=6 (6)
UATHelper: Packaging (Windows (64-bit)): BUILD FAILED
PackagingResults: Error: Unknown Error
```

Looking at UnrealJS.uplugin, all module types have changed to Editor.

If this Type is set to Editor, it will not be loaded in the shipping build, so it is thought that the above phenomenon occurred.

Modules other than "JavascriptGraphEditor", "JavascriptEditor", and "JavascriptConsole" do not refer to "UnrealEd", and I think they should be usable in the shipping build, so I think the Type must be Runtime.

