### PR TITLE
Fix compile errors

### DIFF
--- a/Source/JavascriptEditor/JavascriptOnEditorCommandlet.cpp
+++ b/Source/JavascriptEditor/JavascriptOnEditorCommandlet.cpp
@@ -23,6 +23,40 @@ DEFINE_LOG_CATEGORY(LogJavascriptOnEditor);
 
 #define LOCTEXT_NAMESPACE "UnrealJSEditor"
 
+#if WITH_EDITOR
+static void PatchReimportRule()
+{
+	FAutoReimportWildcard WildcardToInject;
+	WildcardToInject.Wildcard = TEXT("Scripts/**.json");
+	WildcardToInject.bInclude = false;
+
+	auto Default = GetMutableDefault<UEditorLoadingSavingSettings>();
+	bool bHasChanged = false;
+	for (auto& Setting : Default->AutoReimportDirectorySettings)
+	{
+		bool bFound = false;
+		for (const auto& Wildcard : Setting.Wildcards)
+		{
+			if (Wildcard.Wildcard == WildcardToInject.Wildcard)
+			{
+				bFound = true;
+				break;
+			}
+		}
+		if (!bFound)
+		{
+			Setting.Wildcards.Add(WildcardToInject);
+			bHasChanged = true;
+		}
+	}
+	if (bHasChanged)
+	{
+		Default->PostEditChange();
+	}
+}
+#endif
+
+
 UJavascriptOnEditorCommandlet::UJavascriptOnEditorCommandlet(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {}

--- a/Source/JavascriptGraphEditor/JavascriptGraphEdNodeCreator.h
+++ b/Source/JavascriptGraphEditor/JavascriptGraphEdNodeCreator.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "EdGraph/EdGraph.h"
+#include "JavascriptGraphEdNode_Comment.h"
 
 // Forward decl.
 class UJavascriptGraphEdGraph;

--- a/Source/JavascriptGraphEditor/JavascriptGraphTextPropertyEditableTextBox.h
+++ b/Source/JavascriptGraphEditor/JavascriptGraphTextPropertyEditableTextBox.h
@@ -5,6 +5,7 @@
 #include "Components/Widget.h"
 #include "Types/SlateStructs.h"
 #include "JavascriptUMG/JavascriptUMGLibrary.h"
+#include "JavascriptGraphEditorLibrary.h"
 #include "JavascriptGraphTextPropertyEditableTextBox.generated.h"
 
 class FJavascriptEditableTextGraphPin;

--- a/Source/JavascriptGraphEditor/SJavascriptGraphEdNode.cpp
+++ b/Source/JavascriptGraphEditor/SJavascriptGraphEdNode.cpp
@@ -9,6 +9,7 @@
 #include "JavascriptUMG/JavascriptUMGLibrary.h"
 #include "SCommentBubble.h"
 #include "SlateOptMacros.h"
+#include "SGraphPanel.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/SBoxPanel.h"

--- a/Source/JavascriptGraphEditor/SJavascriptGraphNodeComment.h
+++ b/Source/JavascriptGraphEditor/SJavascriptGraphNodeComment.h
@@ -9,8 +9,9 @@
 #include "Input/Reply.h"
 #include "SNodePanel.h"
 #include "SGraphNodeResizable.h"
+#include "JavascriptGraphEdNode_Comment.h"
 
-class UJavascriptGraphEdNode_Comment;
+
 class SCommentBubble;
 
 class SJavascriptGraphNodeComment : public SGraphNodeResizable


### PR DESCRIPTION
I failed to compile source tree with 5.1 installed build from Epic Games Launcher. All of errors are related to compilation unit scope, so I suspect that those errors are hidden by unity build during development.
The PR adds missing includes, and copy-pastes single static helper function.