### PR TITLE
Added EC6 Module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unreal.js-core
+# Unreal.js-core kesselman dev fork
 
 - core component of [Unreal.js](https://github.com/ncsoft/Unreal.js)
 - Please visit [project repo](https://github.com/ncsoft/Unreal.js).

--- a/Source/V8/Private/JavaScriptModuleCompiler.cpp
+++ b/Source/V8/Private/JavaScriptModuleCompiler.cpp
@@ -1,0 +1,195 @@
+﻿#include "JavaScriptModuleCompiler.h"
+
+namespace module_compiler
+{
+	/*****************************************************************************
+	 * char* readFile
+	 * Reads file contents to a null-terminated string.
+	 *****************************************************************************/
+	char* readFile(char filename[]) {
+
+		// Opening file; ifstream::ate is use to determine file size
+		std::ifstream file;
+		file.open(filename, std::ifstream::ate);
+		char* contents;
+		if (!file) {
+			contents = new char[1];
+			return contents;
+		}
+
+		// Get file size
+		size_t file_size = file.tellg();
+
+		// Return file pointer from end of the file (set by ifstream::ate) to beginning
+		file.seekg(0);
+
+		// Reading file to char array and returing it
+		std::filebuf* file_buf = file.rdbuf();
+		contents = new char[file_size + 1]();
+		file_buf->sgetn(contents, file_size);
+		file.close();
+		return contents;
+	}
+
+	/*****************************************************************************
+	 * void print
+	 * Binding of simple console print function to the VM
+	 *****************************************************************************/
+	void print(const v8::FunctionCallbackInfo<v8::Value>& args) {
+
+		// Getting arguments; error handling
+		v8::Isolate* isolate = args.GetIsolate();
+		v8::String::Utf8Value val(isolate, args[0]);
+		if (*val == nullptr)
+			isolate->ThrowException(
+				v8::String::NewFromUtf8(isolate, "First argument of function is empty")
+					.ToLocalChecked());
+
+		// Printing
+		printf("%s\n", *val);
+	}
+
+	/*****************************************************************************
+	 * v8::MaybeLocal<v8::Module> loadModule
+	 * Loads module from code[] without checking it
+	 *****************************************************************************/
+	v8::MaybeLocal<v8::Module> JSModuleCompiler::loadModule(char code[],
+									  char name[],
+									  v8::Local<v8::Context> cx) {
+
+		// Convert char[] to VM's string type
+		v8::Local<v8::String> vcode =
+			v8::String::NewFromUtf8(cx->GetIsolate(), code).ToLocalChecked();
+
+		// Create script origin to determine if it is module or not.
+		// Only first and last argument matters; other ones are default values.
+		// First argument gives script name (useful in error messages), last
+		// informs that it is a module.
+		v8::ScriptOrigin origin(
+			v8::String::NewFromUtf8(cx->GetIsolate(), name).ToLocalChecked(),
+			v8::Integer::New(cx->GetIsolate(), 0),
+			v8::Integer::New(cx->GetIsolate(), 0), v8::False(cx->GetIsolate()),
+			v8::Local<v8::Integer>(), v8::Local<v8::Value>(),
+			v8::False(cx->GetIsolate()), v8::False(cx->GetIsolate()),
+			v8::True(cx->GetIsolate()));
+
+		// Compiling module from source (code + origin)
+		v8::Context::Scope context_scope(cx);
+		v8::ScriptCompiler::Source source(vcode, origin);
+		v8::MaybeLocal<v8::Module> mod;
+		mod = v8::ScriptCompiler::CompileModule(cx->GetIsolate(), &source);
+		if (mod.IsEmpty())
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Script failed to load"));
+		}
+		// Returning non-checked module
+		return mod;
+	}
+
+	/*****************************************************************************
+	 * v8::Local<v8::Module> checkModule
+	 * Checks out module (if it isn't nullptr/empty)
+	 *****************************************************************************/
+	v8::Local<v8::Module> JSModuleCompiler::checkModule(v8::MaybeLocal<v8::Module> maybeModule,
+									  v8::Local<v8::Context> cx) {
+
+		// Checking out
+		v8::Local<v8::Module> mod;
+		if (!maybeModule.ToLocal(&mod)) {
+			printf("Error loading module!\n");
+			exit(EXIT_FAILURE);
+		}
+
+		// Instantianing (including checking out depedencies). It uses callResolve
+		// as callback: check #
+		v8::Maybe<bool> result = mod->InstantiateModule(cx, JSModuleCompiler::callResolve);
+		if (result.IsNothing()) {
+			printf("\nCan't instantiate module.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		// Returning check-out module
+		return mod;
+	}
+
+	/*****************************************************************************
+	 * v8::Local<v8::Value> execModule
+	 * Executes module's code
+	 *****************************************************************************/
+	v8::Local<v8::Value> JSModuleCompiler::execModule(v8::Local<v8::Module> mod,
+									v8::Local<v8::Context> cx,
+									bool nsObject) {
+
+		// Executing module with return value
+		v8::Local<v8::Value> retValue;
+		if (!mod->Evaluate(cx).ToLocal(&retValue)) {
+			printf("Error evaluating module!\n");
+			exit(EXIT_FAILURE);
+		}
+
+		// nsObject determins, if module namespace or return value has to be returned.
+		// Module namespace is required during import callback; see lines # and #.
+		if (nsObject)
+			return mod->GetModuleNamespace();
+		else
+			return retValue;
+	}
+
+	/*****************************************************************************
+	 * v8::MaybeLocal<v8::Module> callResolve
+	 * Callback from static import.
+	 *****************************************************************************/
+	v8::MaybeLocal<v8::Module> JSModuleCompiler::callResolve(v8::Local<v8::Context> context,
+										   v8::Local<v8::String> specifier,
+										   v8::Local<v8::Module> referrer) {
+
+		v8::String::Utf8Value str(context->GetIsolate(), specifier);
+
+		// Return unchecked module
+		return loadModule(readFile(*str), *str, context);
+	}
+
+	/*****************************************************************************
+	 * v8::MaybeLocal<v8::Promise> callDynamic
+	 * Callback from dynamic import.
+	 *****************************************************************************/
+	v8::MaybeLocal<v8::Promise> JSModuleCompiler::callDynamic(v8::Local<v8::Context> context,
+											v8::Local<v8::ScriptOrModule> referrer,
+											v8::Local<v8::String> specifier,
+											v8::Local<v8::FixedArray> import_assertions) {
+
+		// Promise resolver: that way promise for dynamic import can be rejected
+		// or full-filed
+		v8::Local<v8::Promise::Resolver> resolver =
+			v8::Promise::Resolver::New(context).ToLocalChecked();
+		v8::MaybeLocal<v8::Promise> promise(resolver->GetPromise());
+
+		// Loading module (with checking)
+		v8::String::Utf8Value name(context->GetIsolate(), specifier);
+		v8::Local<v8::Module> mod =
+			checkModule(loadModule(readFile(*name), *name, context), context);
+		v8::Local<v8::Value> retValue = execModule(mod, context, true);
+
+		// Resolving (fulfilling) promise with module global namespace
+		resolver->Resolve(context, retValue);
+		return promise;
+	}
+
+	/*****************************************************************************
+	 * void callMeta
+	 * Callback for module metadata. 
+	 *****************************************************************************/
+	void JSModuleCompiler::callMeta(v8::Local<v8::Context> context,
+				  v8::Local<v8::Module> module,
+				  v8::Local<v8::Object> meta) {
+
+		// In this example, this is throw-away function. But it shows that you can
+		// bind module's url. Here, placeholder is used.
+		meta->Set(
+			context,
+			v8::String::NewFromUtf8(context->GetIsolate(), "url").ToLocalChecked(),
+			v8::String::NewFromUtf8(context->GetIsolate(), "https://something.sh")
+				.ToLocalChecked());
+	}
+	
+}

--- a/Source/V8/Private/JavaScriptModuleCompiler.cpp
+++ b/Source/V8/Private/JavaScriptModuleCompiler.cpp
@@ -3,6 +3,14 @@
 #include "IV8.h"
 #include "Misc/FileHelper.h"
 
+/********************************************************************
+ * A static class that handles loading and execution EC6 module files
+ * to the V8 engine in the UE5 environment.
+ * Written by Professor Jeff Kesselman MS MFA
+ * Purdue University
+ * 11/23/2023
+ * jpkessel@purdue.edu
+ * ***********************************/
 namespace module_compiler
 {
 	/*****************************************************************************
@@ -153,7 +161,7 @@ namespace module_compiler
 			context->GetEmbedderData(1));
 		FString fqn(*fileroot);
 		fqn = fqn.Append(FString("/"))+FString(*filename);
-		auto foo = *fileroot;
+
 		// Return unchecked module
 		FString Text;
 		if (!FFileHelper::LoadFileToString(Text, *fqn))

--- a/Source/V8/Private/JavaScriptModuleCompiler.cpp
+++ b/Source/V8/Private/JavaScriptModuleCompiler.cpp
@@ -6,7 +6,7 @@ namespace module_compiler
 	 * char* readFile
 	 * Reads file contents to a null-terminated string.
 	 *****************************************************************************/
-	char* readFile(char filename[]) {
+	char* readFile(const char filename[]) {
 
 		// Opening file; ifstream::ate is use to determine file size
 		std::ifstream file;
@@ -120,6 +120,8 @@ namespace module_compiler
 									v8::Local<v8::Context> cx,
 									bool nsObject) {
 
+		cx->GetIsolate()->SetHostImportModuleDynamicallyCallback(callDynamic);
+
 		// Executing module with return value
 		v8::Local<v8::Value> retValue;
 		if (!mod->Evaluate(cx).ToLocal(&retValue)) {
@@ -144,9 +146,13 @@ namespace module_compiler
 										   v8::Local<v8::Module> referrer) {
 
 		v8::String::Utf8Value str(context->GetIsolate(), specifier);
-
+		v8::String::Utf8Value fileroot(context->GetIsolate(),
+			context->GetEmbedderData(0));
+		std::string fqn(*fileroot);
+		fqn = fqn+std::string("/")+std::string(*str);
+    
 		// Return unchecked module
-		return loadModule(readFile(*str), *str, context);
+		return loadModule(readFile(fqn.c_str()), *str, context);
 	}
 
 	/*****************************************************************************

--- a/Source/V8/Private/JavaScriptModuleCompiler.cpp
+++ b/Source/V8/Private/JavaScriptModuleCompiler.cpp
@@ -1,5 +1,8 @@
 ﻿#include "JavaScriptModuleCompiler.h"
 
+#include "IV8.h"
+#include "Misc/FileHelper.h"
+
 namespace module_compiler
 {
 	/*****************************************************************************
@@ -145,14 +148,24 @@ namespace module_compiler
 										   v8::Local<v8::String> specifier,
 										   v8::Local<v8::Module> referrer) {
 
-		v8::String::Utf8Value str(context->GetIsolate(), specifier);
+		v8::String::Utf8Value filename(context->GetIsolate(), specifier);
 		v8::String::Utf8Value fileroot(context->GetIsolate(),
-			context->GetEmbedderData(0));
-		std::string fqn(*fileroot);
-		fqn = fqn+std::string("/")+std::string(*str);
-    
+			context->GetEmbedderData(1));
+		FString fqn(*fileroot);
+		fqn = fqn.Append(FString("/"))+FString(*filename);
+		auto foo = *fileroot;
 		// Return unchecked module
-		return loadModule(readFile(fqn.c_str()), *str, context);
+		FString Text;
+		if (!FFileHelper::LoadFileToString(Text, *fqn))
+		{
+			std::string sfilename(*filename);
+			FString msg = TEXT("Failed to read script file '%s'");
+			UE_LOG(LogJavascript, Warning,
+				TEXT("Failed to read script file '%s'"),
+					sfilename.c_str());
+		}
+		
+		return loadModule(TCHAR_TO_ANSI(*Text), *filename, context);
 	}
 
 	/*****************************************************************************

--- a/Source/V8/Private/JavaScriptModuleCompiler.h
+++ b/Source/V8/Private/JavaScriptModuleCompiler.h
@@ -1,0 +1,39 @@
+﻿#pragma once
+/**********************************************************
+ * Javascript EC6 (modules) compiler
+ * by Jeffrey Kesselman (jpkessel@purdue.edu)
+ * 
+ * Heavily cribbed from https://gist.github.com/surusek/4c05e4dcac6b82d18a1a28e6742fc23e
+ *
+ **********************************************************/
+#include <libplatform/libplatform.h>
+#include <v8.h>
+
+namespace module_compiler
+{
+	class JSModuleCompiler
+	{
+	private:
+		static v8::MaybeLocal<v8::Module> callResolve(v8::Local<v8::Context> context, v8::Local<v8::String> specifier,
+													  v8::Local<v8::Module> referrer);
+		static v8::MaybeLocal<v8::Promise> callDynamic(v8::Local<v8::Context> context, v8::Local<v8::ScriptOrModule> referrer,
+													   v8::Local<v8::String> specifier,
+													   v8::Local<v8::FixedArray> import_assertions);
+		static void callMeta(v8::Local<v8::Context> context, v8::Local<v8::Module> module, v8::Local<v8::Object> meta);
+
+	public:
+		static v8::MaybeLocal<v8::Module> loadModule(char code[],
+										  char name[],
+										  v8::Local<v8::Context> cx);
+
+		// Check, if module isn't empty (or pointer to it); line #221
+		static v8::Local<v8::Module> checkModule(v8::MaybeLocal<v8::Module> maybeModule,
+										  v8::Local<v8::Context> cx);
+
+		// Executes module; line #247
+		static v8::Local<v8::Value> execModule(v8::Local<v8::Module> mod,
+										v8::Local<v8::Context> cx,
+										bool nsObject = false);
+		
+	};
+}

--- a/Source/V8/Private/JavascriptContext_Private.cpp
+++ b/Source/V8/Private/JavascriptContext_Private.cpp
@@ -1784,7 +1784,10 @@ public:
 
 		auto ScriptPath = GetScriptFileFullPath(Filename);
 		FString Text;
-		if (Args.Num() > 0)
+		if (Filename.EndsWith(".mjs")){ // imports cannto be wrapped
+			// no argument support atm
+			Text = Script;
+		} else if (Args.Num() > 0)
 		{
 			FString strArgs = FString::Printf(TEXT("\'%s\'"), *Args[0]);
 			for (int32 i = 1; i < Args.Num(); ++i)

--- a/UnrealJS.uplugin
+++ b/UnrealJS.uplugin
@@ -1,14 +1,14 @@
 ﻿{
   "FileVersion": 3,
-  "FriendlyName": "Unreal.js - Javascript Runtime",
+  "FriendlyName": "Unreal.js.jpk - Fork of Javascript Runtime",
   "Version": 2,
   "VersionName": "0.6.4",
   "FriendlyVersion": "0.6.4",
   "EngineVersion": "5.1.0",
   "Description": "Javascript powered UnrealEngine",
   "Category": "Programming",
-  "CreatedBy": "NCSOFT Corporation",
-  "CreatedByURL": "http://github.com/ncsoft",
+  "CreatedBy": "Professor K",
+  "CreatedByURL": "http://github.com/profk",
   "EnabledByDefault": true,
   "MarketplaceURL" : "com.epicgames.launcher://ue/marketplace/content/be751eedc4a14cc09e39945bc5a531c4",
   "Modules": [


### PR DESCRIPTION
Will load and execute scripts with the extension .mjs as EC6 modules
I hope its reasonably clean.  I kept all my code to a new file except for the hook to invoke it.

This does make it a bit redundant but had the smallest impact on the original codebase.